### PR TITLE
Sanitize cache key inputs

### DIFF
--- a/src/hcaptcha_challenger/agent/collector.py
+++ b/src/hcaptcha_challenger/agent/collector.py
@@ -196,6 +196,14 @@ class Collector:
                 logger.error(f"Reverse processing getcaptcha failed: {err}")
                 self._captcha_payload_queue.put_nowait(None)
 
+    @staticmethod
+    def _slugify(value: str) -> str:
+        """Return a filesystem-friendly representation of ``value``."""
+        value = re.sub(r"[\\/]+", "_", value)
+        value = re.sub(r"[^A-Za-z0-9_-]+", "_", value)
+        value = re.sub(r"_+", "_", value).strip("_")
+        return value or "unknown"
+
     def _create_cache_key(self, captcha_payload: CaptchaPayload) -> Tuple[str, Path]:
         """
 
@@ -205,8 +213,8 @@ class Collector:
         Returns: ./dataset / require_type / prompt / current_time
 
         """
-        request_type = captcha_payload.request_type.value
-        prompt = captcha_payload.get_requester_question()
+        request_type = self._slugify(captcha_payload.request_type.value)
+        prompt = self._slugify(captcha_payload.get_requester_question())
         current_datetime = datetime.now()
         current_time = current_datetime.strftime("%Y%m%d/%Y%m%d%H%M%S%f")
 

--- a/tests/test_collector_cache_key.py
+++ b/tests/test_collector_cache_key.py
@@ -1,0 +1,28 @@
+import re
+from unittest.mock import MagicMock
+
+from hcaptcha_challenger.agent.collector import Collector, CollectorConfig
+from hcaptcha_challenger.models import CaptchaPayload, RequestType
+
+
+PROMPTS = ["../etc/passwd", "what?*is>this|prompt"]
+
+
+def _build_payload(prompt: str) -> CaptchaPayload:
+    return CaptchaPayload(
+        request_type=RequestType.IMAGE_LABEL_BINARY,
+        requester_question={"en": prompt},
+    )
+
+
+def test_create_cache_key_sanitizes_prompt(tmp_path):
+    collector = Collector(page=MagicMock(), collector_config=CollectorConfig(dataset_dir=tmp_path))
+    for prompt in PROMPTS:
+        payload = _build_payload(prompt)
+        _, cache_path = collector._create_cache_key(payload)
+        rel = cache_path.relative_to(tmp_path)
+        # request_type and prompt are separate parts in the path
+        request_type_part, prompt_part = rel.parts[:2]
+        assert re.fullmatch(r"[A-Za-z0-9_-]+", request_type_part)
+        assert re.fullmatch(r"[A-Za-z0-9_-]+", prompt_part)
+        assert ".." not in prompt_part


### PR DESCRIPTION
## Summary
- sanitize request type and prompt values before using them as dataset cache key components
- add tests to ensure prompts with path traversal or special characters are safely slugified

## Testing
- `ruff check src/hcaptcha_challenger/agent/collector.py tests/test_collector_cache_key.py`
- `PYTHONPATH=src pytest tests/test_collector_cache_key.py -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_b_68a615efca088320b897a84e4d67a515